### PR TITLE
Added functional overloads to the IDatabases interface

### DIFF
--- a/NHibernate.Sessions.Operations/CachedDatabaseQuery.cs
+++ b/NHibernate.Sessions.Operations/CachedDatabaseQuery.cs
@@ -1,10 +1,35 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public abstract class CachedDatabaseQuery<T> : AbstractCachedDatabaseQuery<T>, ICachedDatabaseQuery<T>
 	{
 		public virtual T Execute(ISessionManager sessionManager, IDatabaseQueryCache databaseQueryCache = null)
 		{
 			return GetDatabaseResult(sessionManager, databaseQueryCache);
+		}
+	}
+
+	internal class FunctionalCachedDatabaseQuery<T> : CachedDatabaseQuery<T>
+	{
+		readonly Func<ISessionManager, T> _query;
+		readonly Action<CacheConfig> _configureCache;
+
+		public FunctionalCachedDatabaseQuery(Func<ISessionManager, T> query, Action<CacheConfig> configureCache)
+		{
+			_query = query;
+			_configureCache = configureCache;
+		}
+
+		protected override void ConfigureCache(CacheConfig cacheConfig)
+		{
+			if(_configureCache != null)
+				_configureCache(cacheConfig);
+		}
+
+		protected override T QueryDatabase(ISessionManager sessionManager)
+		{
+			return _query(sessionManager);
 		}
 	}
 }

--- a/NHibernate.Sessions.Operations/DatabaseCommand.cs
+++ b/NHibernate.Sessions.Operations/DatabaseCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public abstract class DatabaseCommand : DatabaseOperation, IDatabaseCommand
 	{
@@ -8,5 +10,35 @@
 	public abstract class DatabaseCommand<T> : DatabaseOperation, IDatabaseCommand<T>
 	{
 		public abstract T Execute(ISessionManager sessionManager);
+	}
+
+	internal class FunctionalDatabaseCommand : DatabaseCommand
+	{
+		readonly Action<ISessionManager> _command;
+
+		public FunctionalDatabaseCommand(Action<ISessionManager> command)
+		{
+			_command = command;
+		}
+
+		public override void Execute(ISessionManager sessionManager)
+		{
+			_command(sessionManager);
+		}
+	}
+
+	internal class FunctionalDatabaseCommand<T> : DatabaseCommand<T>
+	{
+		readonly Func<ISessionManager, T> _command;
+
+		public FunctionalDatabaseCommand(Func<ISessionManager, T> command)
+		{
+			_command = command;
+		}
+
+		public override T Execute(ISessionManager sessionManager)
+		{
+			return _command(sessionManager);
+		}
 	}
 }

--- a/NHibernate.Sessions.Operations/DatabaseQuery.cs
+++ b/NHibernate.Sessions.Operations/DatabaseQuery.cs
@@ -1,7 +1,24 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public abstract class DatabaseQuery<T> : DatabaseOperation, IDatabaseQuery<T>
 	{
 		public abstract T Execute(ISessionManager sessionManager);
+	}
+
+	internal class FunctionDatabaseQuery<T> : DatabaseQuery<T>
+	{
+		readonly Func<ISessionManager, T> _query;
+
+		public FunctionDatabaseQuery(Func<ISessionManager, T> query)
+		{
+			_query = query;
+		}
+
+		public override T Execute(ISessionManager sessionManager)
+		{
+			return _query(sessionManager);
+		}
 	}
 }

--- a/NHibernate.Sessions.Operations/Databases.cs
+++ b/NHibernate.Sessions.Operations/Databases.cs
@@ -1,4 +1,6 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public class Databases : IDatabases
 	{
@@ -17,9 +19,25 @@
 			return query.Execute(SessionManager);
 		}
 
+		public T Query<T>(Func<ISessionManager, T> query)
+		{
+			return new FunctionDatabaseQuery<T>(query).Execute(SessionManager);
+		}
+
 		public T Query<T>(ICachedDatabaseQuery<T> query)
 		{
 			return query.Execute(SessionManager, _databaseQueryCache);
+		}
+
+		public T Query<T>(Func<ISessionManager, T> query, Action<CacheConfig> configureCache)
+		{
+
+			return new FunctionalCachedDatabaseQuery<T>(query, configureCache).Execute(SessionManager);
+		}
+
+		public TResult Query<T, TResult>(Func<ISessionManager, T> query, Func<T, TResult> transform, Action<CacheConfig> configureCache)
+		{
+			return new FunctionTransformedCachedDatabaseQuery<T, TResult>(query, transform, configureCache).Execute(SessionManager);
 		}
 
 		public void Command(IDatabaseCommand command)
@@ -27,9 +45,19 @@
 			command.Execute(SessionManager);
 		}
 
+		public void Command(Action<ISessionManager> command)
+		{
+			new FunctionalDatabaseCommand(command).Execute(SessionManager);
+		}
+
 		public T Command<T>(IDatabaseCommand<T> command)
 		{
 			return command.Execute(SessionManager);
+		}
+
+		public T Command<T>(Func<ISessionManager, T> command)
+		{
+			return new FunctionalDatabaseCommand<T>(command).Execute(SessionManager);
 		}
 	}
 }

--- a/NHibernate.Sessions.Operations/IDatabases.cs
+++ b/NHibernate.Sessions.Operations/IDatabases.cs
@@ -1,13 +1,20 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public interface IDatabases
 	{
 		ISessionManager SessionManager { get; }
 
 		T Query<T>(IDatabaseQuery<T> query);
+		T Query<T>(Func<ISessionManager, T> query);
 		T Query<T>(ICachedDatabaseQuery<T> query);
+		T Query<T>(Func<ISessionManager, T> query, Action<CacheConfig> configureCache);
+		TResult Query<T, TResult>(Func<ISessionManager, T> query, Func<T, TResult> transform, Action<CacheConfig> configureCache);
 
 		void Command(IDatabaseCommand command);
+		void Command(Action<ISessionManager> command);
 		T Command<T>(IDatabaseCommand<T> command);
+		T Command<T>(Func<ISessionManager, T> command);
 	}
 }

--- a/NHibernate.Sessions.Operations/Properties/AssemblyInfo.cs
+++ b/NHibernate.Sessions.Operations/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.0")]
-[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyFileVersion("1.3.0")]
 
 [assembly: InternalsVisibleTo("NHibernate.Sessions.Operations.Tests")]

--- a/NHibernate.Sessions.Operations/TransformedCachedDatabaseQuery.cs
+++ b/NHibernate.Sessions.Operations/TransformedCachedDatabaseQuery.cs
@@ -1,4 +1,6 @@
-﻿namespace NHibernate.Sessions.Operations
+﻿using System;
+
+namespace NHibernate.Sessions.Operations
 {
 	public abstract class TransformedCachedDatabaseQuery<TDatabaseResult, TTransformedResult> : AbstractCachedDatabaseQuery<TDatabaseResult>, ICachedDatabaseQuery<TTransformedResult>
 	{
@@ -7,6 +9,36 @@
 		public TTransformedResult Execute(ISessionManager sessionManager, IDatabaseQueryCache databaseQueryCache = null)
 		{
 			return TransformDatabaseResult(GetDatabaseResult(sessionManager, databaseQueryCache));
+		}
+	}
+
+	internal class FunctionTransformedCachedDatabaseQuery<TDatabaseResult, TTransformedResult> : TransformedCachedDatabaseQuery<TDatabaseResult, TTransformedResult>
+	{
+		readonly Func<ISessionManager, TDatabaseResult> _query;
+		readonly Func<TDatabaseResult, TTransformedResult> _transform;
+		readonly Action<CacheConfig> _configureCache;
+
+		public FunctionTransformedCachedDatabaseQuery(Func<ISessionManager, TDatabaseResult> query, Func<TDatabaseResult, TTransformedResult> transform, Action<CacheConfig> configureCache)
+		{
+			_query = query;
+			_transform = transform;
+			_configureCache = configureCache;
+		}
+
+		protected override void ConfigureCache(CacheConfig cacheConfig)
+		{
+			if (_configureCache != null)
+				_configureCache(cacheConfig);
+		}
+
+		protected override TDatabaseResult QueryDatabase(ISessionManager sessionManager)
+		{
+			return _query(sessionManager);
+		}
+
+		protected override TTransformedResult TransformDatabaseResult(TDatabaseResult databaseResult)
+		{
+			return _transform(databaseResult);
 		}
 	}
 }


### PR DESCRIPTION
This allows for the following patterns:

```
var result = _databases(s => s.Session.Query<Person>());
```

or, more elaborate

```
class Q
{
    public readonly static Func<ISessionManager, List<Person>> GetAllPeople = s =>
        s.Session.Query<Person>();
}
var people = _database.Query(Q.GetAllPeople);
```

or with parameters

```
class Q
{
    public static Func<ISessionManager, Person> GetPersonById(int Id)
    {
        return s => s.Session.Get<Person>(id);
    }
}

_database.Query(Q.GetPersonById(27));
```

The same goes for the cached versions and the commands
